### PR TITLE
Document commands and keys in the README also

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,34 @@ Transpose words::
 	>>> readlike.edit('perilous siege', 9, 'meta t')
 	('siege perilous', 14)
 
+Commands
+--------
+
+Implemented commands and their correspondings keys are as follows::
+
+    backward-char            ctrl b, left
+    backward-delete-char     ctrl h, backspace
+    backward-kill-word       ctrl meta h, meta backspace
+    backward-word            meta b, meta left
+    beginning-of-line        ctrl a, home
+    capitalize-word          meta c
+    delete-char              ctrl d, delete
+    delete-horizontal-space  meta \\
+    downcase-word            meta l
+    end-of-line              ctrl e, end
+    forward-char             ctrl f, right
+    forward-word             meta f, meta right
+    kill-line                ctrl k
+    kill-word                meta d, meta delete
+    transpose-chars          ctrl t
+    transpose-words          meta t
+    unix-line-discard        ctrl u
+    unix-word-rubout         ctrl w
+    upcase-word              meta u
+
+For more information about each command, see readline(3) or see the doc
+strings in readlike.py_.
+
 Projects using Readlike
 -----------------------
 
@@ -37,4 +65,5 @@ Projects using Readlike
 .. _readline: https://docs.python.org/3/library/readline.html
 .. _PyPI: https://pypi.python.org/pypi/readlike
 .. _Urwid: http://urwid.org/
+.. _readlike.py: https://github.com/jangler/readlike/blob/master/readlike.py
 .. _hangups: https://github.com/tdryer/hangups


### PR DESCRIPTION
At the risk of having to update these in two places in the future, I think it's important to list these commands/keys in the README. I had to do a little digging to see what was supported and I was coming from the perspective of a user of [Hangups](http://github.com/tdryer/hangups) rather than a user of this particular library.

I am preparing a PR to update the documentation of that project as it does not mention that it has readline/readlike support (you have to read the source to find out). I'm not sure the author will want a big blob of bindings in his README considering a number of them clash with his default bindings. But the bindings could be linked to from the Hangups documentation if it were in your README!

Lastly, thanks very much for developing this library and integrating it into Hangups! It's always frustrating using a terminal app that doesn't support at least some of the readline commands.